### PR TITLE
Add images for Enterprise Android Framework

### DIFF
--- a/config/experience.ts
+++ b/config/experience.ts
@@ -491,12 +491,19 @@ export const Experiences: ExperienceInterface[] = [
       {
         title: "Core Modules",
         description: "Reusable libraries enabling scalable app development",
-        imgArr: ["/experience/enterprise-android-framework/logo.png"],
+        imgArr: [
+          "/experience/enterprise-android-framework/a.jpg",
+          "/experience/enterprise-android-framework/b.webp",
+          "/experience/enterprise-android-framework/c.jpg",
+        ],
       },
       {
         title: "Performance Suite",
         description: "Tools for profiling, memory analysis, and automated testing",
-        imgArr: ["/experience/enterprise-android-framework/logo.png"],
+        imgArr: [
+          "/experience/enterprise-android-framework/b.webp",
+          "/experience/enterprise-android-framework/c.jpg",
+        ],
       },
     ],
     descriptionDetails: {


### PR DESCRIPTION
## Summary
- update `Enterprise Android Framework` images to use a/b/c pics

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854329bb4d8832cbc1ca38016506208