### PR TITLE
Add SeaDroid contribution

### DIFF
--- a/config/contributions.ts
+++ b/config/contributions.ts
@@ -27,6 +27,13 @@ export const contributionsUnsorted: contributionsInterface[] = [
     repoOwner: "Creative Commons",
     link: "https://github.com/creativecommons/creativecommons.github.io-source/pull/719",
   },
+  {
+    repo: "seadroid",
+    contibutionDescription:
+      "Maintainer of the SeaDroid open-source project.",
+    repoOwner: "Logan676",
+    link: "https://github.com/Logan676/seadroid",
+  },
 ];
 
 export const featuredContributions: contributionsInterface[] =


### PR DESCRIPTION
## Summary
- list SeaDroid under open-source contributions

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68544119aab0832c8ba8bead86e6817b